### PR TITLE
Increase max file upload to 100 MB

### DIFF
--- a/src/IsaacHili.InstagramTools.App/Pages/Followers.razor
+++ b/src/IsaacHili.InstagramTools.App/Pages/Followers.razor
@@ -154,9 +154,11 @@
 			return;
 		}
 
+		const int maxSize = 100 * 1000 * 1000; // 100 MB
+
 		// Copy archive to memory stream
 		using var stream = new MemoryStream();
-		await e.File.OpenReadStream().CopyToAsync(stream);
+		await e.File.OpenReadStream(maxSize).CopyToAsync(stream);
 
 		// Read memory stream
 		await connectionsService.LoadConnectionsAsync(stream);


### PR DESCRIPTION
File uploads are currently limited to 512 KB, which is too limited for accounts with a larger following. Increasing the limit to 100 MB should be more than enough for P99 of the Instagram user base.