### PR TITLE
Add missing canonical URL

### DIFF
--- a/src/IsaacHili.InstagramTools.App/wwwroot/index.html
+++ b/src/IsaacHili.InstagramTools.App/wwwroot/index.html
@@ -8,7 +8,7 @@
 	<!-- Metadata -->
 	<meta charset="UTF-8">
 	<meta name="author" content="Isaac Hili">
-	<meta name="description" content="Explore your Instagram connections with Instagram Tools! See mutual followers, track one-way follows, and stay updated on who’s new to your circle." />
+	<meta name="description" content="Explore your Instagram connections with Instagram Tools! See mutual followers, track one-way follows, and stay updated on who&apos;s new to your circle." />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 	<!-- Style -->
@@ -16,6 +16,9 @@
 
 	<!-- Favicon -->
 	<link rel="shortcut icon" href="assets/icons/favicon.ico">
+
+	<!-- Canonical URL -->
+	<link rel="canonical" href="https://instagram-tools.isaachili.com/">
 
 	<!-- Title -->
 	<title>Instagram Tools</title>


### PR DESCRIPTION
Adds the missing canonical URL which is needed to avoid indexing of the Preview website.